### PR TITLE
Replaced the logic of the `jinx restart` and you can set your IP addresses in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,10 @@ uninstall                                uninstall jinx (aw!)
 
 Test the configuration file: nginx checks the configuration for correct syntax, and then tries to open files referred in the configuration. 
 
+### `jinx restart`
+
+The sequence of the two commands your nginx server - `service nginx stop` and `service nginx start`. In most cases, a softer command is enough - `jinx reload`
+
 ### `jinx reload`
 
 Reload configuration nginx, start the new worker process with a new configuration, gracefully shut down old worker processes.

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ config <key> <value>                     set config value in ~/.jinx/config
 site activate <name> [--restart|-r]      activate a site
 site deactivate <name> [--restart|-r]    deactivate a site
 site delete <name> [--yes|-y]            delete a site
-site create <name> [<template>]          create a site from template
+site create <name> [ipv4=<ipv4 address>] [ipv6=<ipv6 address>] [<template>]          create a site from template
 site edit <name>                         edit a site .conf file with editor
 
 start                                    start nginx service
@@ -296,6 +296,8 @@ server {
     index index.html index.htm;
 }
 ```
+
+Other replacement variables are also available - `_IPv4_` and `_IPv6_`. Through them you can set your desired IPv4 and|or IPv4 address. The case when many IPv4 or IPv6 addresses are assigned, they are not yet implemented.
 
 ## Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -141,17 +141,27 @@ site edit <name>                         edit a site .conf file with editor
 
 start                                    start nginx service
 restart                                  restart nginx service
+reload                                   reload nginx service
 stop                                     stop nginx service
 logs                                     get nginx error logs
+check | -t | --check                     check syntax of nginx configs without reboot or reload nginx
 
-version                                  output jinx version number
+version | -v | --version                 output jinx version number
 update                                   update to latest version
 uninstall                                uninstall jinx (aw!)
 ```
 
-### `jinx start|restart|stop`
+### `jinx check|-t|--check`
 
-Does as it says. These commands start, restart or stop your nginx server.
+Test the configuration file: nginx checks the configuration for correct syntax, and then tries to open files referred in the configuration. 
+
+### `jinx reload`
+
+Reload configuration nginx, start the new worker process with a new configuration, gracefully shut down old worker processes.
+
+### `jinx start|stop`
+
+Does as it says. These commands start or stop your nginx server.
 
 ### `jinx logs`
 

--- a/jinx
+++ b/jinx
@@ -57,7 +57,7 @@ for arg in "$@"
 do
     case $arg in
         # Utilities
-        help)
+        help | -h | --help)
             jinx_help
             exit 0
         ;;
@@ -86,7 +86,7 @@ do
         uninstall)
             jinx_uninstall $2
         ;;
-        version)
+        version | -v | --version)
             echo -e "$JINX_VERSION"
             exit 0
         ;;
@@ -116,6 +116,18 @@ do
         ;;
 
         # Service management
+        check | -t | --check)
+            jinx_nginx_service "check"
+        ;;
+        start)
+            jinx_nginx_service "start"
+        ;;
+        stop)
+            jinx_nginx_service "stop"
+        ;;
+        reload)
+            jinx_nginx_service "reload"
+        ;;
         restart)
             jinx_nginx_service "restart"
         ;;

--- a/jinx
+++ b/jinx
@@ -104,7 +104,7 @@ do
                 jinx_site_edit $3
             elif [[ "$2" == "create" ]]
             then
-                jinx_site_create $3 $4
+                jinx_site_create $3 $4 $5 $6
             elif [[ "$2" == "delete" ]]
             then
                 jinx_site_delete $3 $4

--- a/jinx
+++ b/jinx
@@ -131,12 +131,6 @@ do
         restart)
             jinx_nginx_service "restart"
         ;;
-        stop)
-            jinx_nginx_service "stop"
-        ;;
-        start)
-            jinx_nginx_service "start"
-        ;;
         logs)
             jinx_nginx_logs
         ;;

--- a/modules/60-jinx-site.sh
+++ b/modules/60-jinx-site.sh
@@ -90,10 +90,21 @@ jinx_site_create() {
          exit 1
     fi
 
-    if [[ ! -z "$2" ]]
-    then
-         local CONFIG_TEMPLATE="$2"
-    fi
+    local DOMAIN=$1
+
+    while [ $# -ne 0 ]
+    do
+        if [[ "$(echo $1 | awk -F= '{print tolower($1)}')" = "ipv4" ]]
+        then
+            local IPv4=$(echo $1 | awk -F= '{print $2}')
+        elif [[ "$(echo $1 | awk -F= '{print tolower($1)}')" = "ipv6" ]]
+        then
+            local IPv6=$(echo $1 | awk -F= '{print $2}')
+        else
+            local CONFIG_TEMPLATE="$1"
+        fi
+        shift
+    done
 
     local NGINX_PATH=$(jinx_config_get "nginx_path")
     local CONFIG_PATH=$(jinx_config_get "config_path")

--- a/modules/60-jinx-site.sh
+++ b/modules/60-jinx-site.sh
@@ -110,7 +110,7 @@ jinx_site_create() {
     local CONFIG_PATH=$(jinx_config_get "config_path")
     local TEMPLATE_PATH="$NGINX_PATH/$CONFIG_PATH/"
     local TEMPLATE_FILE="$TEMPLATE_PATH/$CONFIG_TEMPLATE.conf"
-    local NEW_FILE_PATH="$NGINX_PATH/sites-available/$1.conf"
+    local NEW_FILE_PATH="$NGINX_PATH/sites-available/$DOMAIN.conf"
 
     if [[ ! -f "$TEMPLATE_FILE" ]]
     then
@@ -120,12 +120,12 @@ jinx_site_create() {
 
     if [[ -f "$NEW_FILE_PATH" ]]
     then
-         echo -e "${COLOR_RED}Failure.${FORMAT_END} Site '$1' already exists. Please choose another name."
+         echo -e "${COLOR_RED}Failure.${FORMAT_END} Site '$DOMAIN' already exists. Please choose another name."
          exit 1
     fi
 
     cp "$TEMPLATE_FILE" "$NEW_FILE_PATH"
-    sed -i -e "s/___/$1/g" "$NEW_FILE_PATH"
+    sed -i -e "s/___/$DOMAIN/g" "$NEW_FILE_PATH"
 
     if [[ -n "$IPv4" ]]
     then

--- a/modules/60-jinx-site.sh
+++ b/modules/60-jinx-site.sh
@@ -3,6 +3,7 @@
 jinx_optional_restart() {
     case "$1" in
         --restart|-r) jinx_nginx_service "restart";;
+        *) jinx_nginx_service "reload";;
     esac
 }
 

--- a/modules/60-jinx-site.sh
+++ b/modules/60-jinx-site.sh
@@ -127,7 +127,17 @@ jinx_site_create() {
     cp "$TEMPLATE_FILE" "$NEW_FILE_PATH"
     sed -i -e "s/___/$1/g" "$NEW_FILE_PATH"
 
-    echo -e "${COLOR_GREEN}Success.${FORMAT_END} Site '$1' was created and can now be activated."
+    if [[ -n "$IPv4" ]]
+    then
+        sed -i -e "s/_IPv4_/$IPv4/g" "$NEW_FILE_PATH"
+    fi
+
+    if [[ -n "$IPv6" ]]
+    then
+        sed -i -e "s/_IPv6_/$IPv6/g" "$NEW_FILE_PATH"
+    fi
+
+    echo -e "${COLOR_GREEN}Success.${FORMAT_END} Site '$DOMAIN' was created and can now be activated."
     exit 0
 }
 

--- a/modules/70-jinx-nginx.sh
+++ b/modules/70-jinx-nginx.sh
@@ -2,9 +2,11 @@
 
 jinx_nginx_service() {
     case "$1" in
-        start) nginx ;;
-        stop) nginx -s stop ;;
-        restart) nginx -s reload ;;
+        check) nginx -t ;;
+        start) service nginx start ;;
+        stop) service nginx stop ;;
+        reload) service nginx reload ;;
+        restart) service nginx restart ;;
     esac
 
     if [[ $? -eq 0 ]]


### PR DESCRIPTION
### Proposed changes

*  Replaced the logic of the `jinx restart` argument. Now this is valid restart nginx server. The reload argument - `jinx reload` is recommended for applying nginx configs changes.

### Resolved issue (if any)

Fixes #4 

